### PR TITLE
Enable powerTorch with screen on

### DIFF
--- a/app/src/main/java/com/darkeyes/tricks/Main.java
+++ b/app/src/main/java/com/darkeyes/tricks/Main.java
@@ -97,7 +97,8 @@ public class Main implements IXposedHookZygoteInit, IXposedHookLoadPackage {
     private PowerManager.WakeLock mWakeUpWakeLock;
     private int MSG_WAKE_UP = 100;
     private ArrayMap<String, Long> mLastTimestamps = new ArrayMap<>();
-    private long mDownTime = 0L;
+    private boolean mVolumeUp = false;
+    private boolean mVolumeDown = false;
     private boolean mCameraGesture;
     private GestureDetector mDoubleTapGesture;
     private Object mNotificationPanelViewController;
@@ -1116,12 +1117,25 @@ public class Main implements IXposedHookZygoteInit, IXposedHookLoadPackage {
                                 }
                             }
 
-                            if (keyCode == KeyEvent.KEYCODE_POWER && mPowerManager.isInteractive()) {
-                                mDownTime = event.getEventTime();
+                            if (keyCode == KeyEvent.KEYCODE_VOLUME_UP) {
+                                if (event.getAction() == KeyEvent.ACTION_DOWN && mPowerManager.isInteractive()) {
+                                    mVolumeUp = true;
+                                }
+                                else {
+                                    mVolumeUp = false;
+                                }
                             }
 
-                            if (keyCode == KeyEvent.KEYCODE_POWER && ((!mPowerManager.isInteractive() &&
-                                    (event.getEventTime() - mDownTime > 300)) || mTorchEnabled) && event.getSource() != InputDevice.SOURCE_UNKNOWN) {
+                            if (keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) {
+                                if (event.getAction() == KeyEvent.ACTION_DOWN && mPowerManager.isInteractive()) {
+                                    mVolumeDown = true;
+                                }
+                                else {
+                                    mVolumeDown = false;
+                                }
+                            }
+
+                            if (keyCode == KeyEvent.KEYCODE_POWER && mVolumeUp == false && mVolumeDown == false && event.getSource() != InputDevice.SOURCE_UNKNOWN) {
                                 if (mSensorManager == null)
                                     mSensorManager = (SensorManager) mContext.getSystemService(Context.SENSOR_SERVICE);
                                 if (mProximitySensor == null)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="skipTrack_title">Volume keys skip track</string>
     <string name="skipTrack_summary">Skip track by long pressing volume keys while screen is off</string>
     <string name="powerTorch_title">Power key toggles torch</string>
-    <string name="powerTorch_summary">Toggle torch by long pressing power key while screen is off</string>
+    <string name="powerTorch_summary">Toggle torch by long pressing power key</string>
     <string name="proximityWakeUp_title">Prevent accidental wake up</string>
     <string name="proximityWakeUp_summary">Check the proximity sensor before waking up the phone</string>
     <string name="lessNotifications_title">Less frequent notifications (sound and vibration)</string>


### PR DESCRIPTION
I would like powerTorch to also work with the screen on.

The difficult part seems to be still allowing the combo/multi button long presses to function.

Obviously with the combo's you try to press the buttons at the same time, but inevitably one button is pressed a fraction before the other.

This code allows the `volumeUp+power` (power menu) and `volumeDown+power` (screenshot) to work correctly.

But doesn't detect `power+volumeUp` and `power+volumeDown`, and instead toggles the torch.

Any hints on how to do this better would be appreciated.

I tried adding `InputMethodService.onKeyDown()` and `InputMethodService.onKeyUp()` but they didn't have any noticeable effect.

Also, if you were to accept such a feature addition what would be the best way to add it; would it be best to change the existing powerTorch, or leave it alone and add this as a new option?